### PR TITLE
Potential fix for code scanning alert no. 3: Log Injection

### DIFF
--- a/src/main/java/ch/oceandive/controller/web/DiveLogMVCController.java
+++ b/src/main/java/ch/oceandive/controller/web/DiveLogMVCController.java
@@ -122,8 +122,10 @@ public class DiveLogMVCController {
               : currentUser.getUsername());
       model.addAttribute("isAdmin", isCurrentUserAdmin());
 
+      // Sanitize the location string to prevent log injection
+      String sanitizedDiveLocation = diveLocation.replaceAll("[\\r\\n]", "");
       logger.debug("Loaded {} dive logs for user: {} with location filter: '{}'",
-          diveLogs.size(), currentUser.getUsername(), diveLocation);
+          diveLogs.size(), currentUser.getUsername(), sanitizedDiveLocation);
     } catch (Exception e) {
       logger.error("Error loading dive logs with location filter: {}", location, e);
       model.addAttribute("errorMessage", "Failed to load dive logs. Please try again.");


### PR DESCRIPTION
Potential fix for [https://github.com/samehinttech/diving-courses-trips-logbook-project/security/code-scanning/3](https://github.com/samehinttech/diving-courses-trips-logbook-project/security/code-scanning/3)

To fix this problem, we need to sanitize the user input (`location` parameter), specifically before it is logged. The best approach is to strip or replace all line-breaks and control characters (including `\n`, `\r`), ideally all characters outside a conservative printable ASCII range, or at the very least mark and escape problematic content. We should sanitize or escape `diveLocation` before logging on line 125. This can be done by replacing line-breaks with spaces, or removing them entirely, using `String.replaceAll("[\\r\\n]", "")`. We should perform this escaping just before logging, so all other code logic still uses the original value. Add a helper utility method if not present, or do the sanitization inline prior to the logging statement.

Code changes required:
- In the logging statement on line 125, ensure `diveLocation` is sanitized using `replaceAll("[\\r\\n]", "")` before it is logged.
- This can be done inline; if used elsewhere a utility method could be justified, but based on the code snippet only line 125 requires this change.
- No dependencies are needed, as this uses the standard `String.replaceAll`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
