### PR TITLE
Potential fix for code scanning alert no. 6: Log Injection

### DIFF
--- a/src/main/java/ch/oceandive/controller/rest/TripController.java
+++ b/src/main/java/ch/oceandive/controller/rest/TripController.java
@@ -94,7 +94,7 @@ public class TripController {
     // End point to get a trip by its slug (stored in the database) for Admin Level
     @GetMapping("/slug/{slug}")
     public ResponseEntity<?> getTripBySlug(@Parameter(description = "Trip slug") @PathVariable String slug) {
-        logger.debug("Getting trip by slug: {}", slug);
+        logger.debug("Getting trip by slug: {}", sanitizeForLog(slug));
         try {
             Trip trip = tripService.getTripBySlug(slug);
             return ResponseEntity.ok(trip);


### PR DESCRIPTION
Potential fix for [https://github.com/samehinttech/diving-courses-trips-logbook-project/security/code-scanning/6](https://github.com/samehinttech/diving-courses-trips-logbook-project/security/code-scanning/6)

To prevent log injection, sanitize the `slug` value before logging it. This can be done using the existing utility method `sanitizeForLog(String input)` already defined in this class (lines 41-45). This method removes newline (`\n`) and carriage return (`\r`) characters that could be used to inject extra log lines.

The best way to fix the issue is to update the logging on line 97 to use `sanitizeForLog(slug)` instead of `slug`. The rest of the method can continue to use the unsanitized value if required by business logic, but only the log statement needs to be updated to use the sanitized version.

No new methods or imports are needed; simply change the logger call to sanitize the log data.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
